### PR TITLE
Feature/routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "parcel": "^2.8.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.9.0",
         "react-test-renderer": "^18.2.0",
         "sequelize": "^6.29.3",
         "sqlite3": "^5.1.6"
@@ -4023,6 +4024,14 @@
       },
       "peerDependencies": {
         "@parcel/core": "^2.8.3"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.4.0.tgz",
+      "integrity": "sha512-BJ9SxXux8zAg991UmT8slpwpsd31K1dHHbD3Ba4VzD+liLQ4WAMSxQp2d2ZPRPfN0jN2NPRowcSSoM7lCaF08Q==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -10107,6 +10116,36 @@
       "integrity": "sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.9.0.tgz",
+      "integrity": "sha512-51lKevGNUHrt6kLuX3e/ihrXoXCa9ixY/nVWRLlob4r/l0f45x3SzBvYJe3ctleLUQQ5fVa4RGgJOTH7D9Umhw==",
+      "dependencies": {
+        "@remix-run/router": "1.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.9.0.tgz",
+      "integrity": "sha512-/seUAPY01VAuwkGyVBPCn1OXfVbaWGGu4QN9uj0kCPcTyNYgL1ldZpxZUpRU7BLheKQI4Twtl/OW2nHRF1u26Q==",
+      "dependencies": {
+        "@remix-run/router": "1.4.0",
+        "react-router": "6.9.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-shallow-renderer": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "parcel": "^2.8.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.9.0",
     "react-test-renderer": "^18.2.0",
     "sequelize": "^6.29.3",
     "sqlite3": "^5.1.6"

--- a/public/react/components/App.js
+++ b/public/react/components/App.js
@@ -1,50 +1,72 @@
-import React, { useState, useEffect } from 'react';
-import { SaucesList } from './SaucesList';
-import { ItemsList } from './ItemsList'
-import { Item } from './Item'
+import React, { useState, useEffect } from "react";
+import { ItemsList } from "./ItemsList";
+import { Route, Routes, Link, useParams } from "react-router-dom";
 
 // import and prepend the api url to any fetch calls
-import apiURL from '../api';
+import apiURL from "../api";
+
+const ComponentWithID = () => {
+  const { id } = useParams();
+  return <div>ID is {id}</div>;
+};
 
 export const App = () => {
+  const [sauces, setSauces] = useState([]);
+  const [items, setItems] = useState([]);
 
-	const [sauces, setSauces] = useState([]);
-	const [items, setItems] = useState([])
+  async function fetchSauces() {
+    try {
+      const response = await fetch(`${apiURL}/sauces`);
+      const saucesData = await response.json();
+      setSauces(saucesData);
+    } catch (err) {
+      console.log("Oh no an error! ", err);
+    }
+  }
 
-	async function fetchSauces(){
-		try {
-			const response = await fetch(`${apiURL}/sauces`);
-			const saucesData = await response.json();
-			setSauces(saucesData); 
-		} catch (err) {
-			console.log("Oh no an error! ", err)
-		}
-	}
+  useEffect(() => {
+    fetchSauces();
+  }, []);
 
-	useEffect(() => {
-		fetchSauces();
-	}, []);
+  //GET fetch request for all items
+  async function fetchItems() {
+    try {
+      const res = await fetch(`${apiURL}/items`);
+      const itemsData = await res.json();
+      setItems(itemsData);
+    } catch (err) {
+      console.log("Error!", err);
+    }
+  }
 
-	//GET fetch request for all items
-	async function fetchItems(){
-		try {
-			const res = await fetch(`${apiURL}/items`);
-			const itemsData = await res.json();
-			setItems(itemsData)
-		} catch (err){
-			console.log('Error!', err)
-		}
-	}
+  useEffect(() => {
+    fetchItems();
+  }, []);
 
-	useEffect(() => {
-		fetchItems();
-	}, []);
-
-	return (
-		<main>	
-      		<h1 className='heading'>Sauce Store</h1>
-			<h3 id='heading2'>All things 🔥</h3>
-			<ItemsList items={items} />
-		</main>
-	)
-}
+  return (
+    <div>
+      <Link to="/">Home</Link>
+      <Link to="/items">items</Link>
+      {[1, 2, 3].map((id) => (
+        <Link to={`/item/${id}`}>Link to: {id}</Link>
+      ))}
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <main>
+              <h1>Home</h1>
+            </main>
+          }
+        />
+        <Route path="/item/:id" element={<ComponentWithID />} />
+      </Routes>
+    </div>
+  );
+};
+// temporary
+// {/* <main> */}
+// {/*   <h1 className="heading">Sauce Store</h1> */}
+// {/*   <h3 id="heading2">All things 🔥</h3> */}
+// {/*   <ItemsList items={items} /> */}
+// {/* </main> */}

--- a/public/react/components/App.js
+++ b/public/react/components/App.js
@@ -1,14 +1,9 @@
 import React, { useState, useEffect } from "react";
 import { ItemsList } from "./ItemsList";
-import { Route, Routes, Link, useParams } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 
 // import and prepend the api url to any fetch calls
 import apiURL from "../api";
-
-const ComponentWithID = () => {
-  const { id } = useParams();
-  return <div>ID is {id}</div>;
-};
 
 export const App = () => {
   const [sauces, setSauces] = useState([]);
@@ -46,6 +41,10 @@ export const App = () => {
   return (
     <div>
       <Routes>
+        {/* TODO: create main view */}
+        {/* this file (app) should only have routes */}
+        {/* main view should have itemslist etc */}
+        <Route path="/" element={<ItemsList items={items} />} />
         {/* TODO: this will link to an item component  */}
         {/* Link will be inside itemslist in this format: */}
         {/* {items.map((id) => ( */}

--- a/public/react/components/App.js
+++ b/public/react/components/App.js
@@ -1,6 +1,5 @@
 //  this file (app) should only have routes
 // main view should have itemslist etc
-import React, { useState, useEffect } from "react";
 import { MainView } from "./MainView";
 import { Route, Routes, useParams } from "react-router-dom";
 

--- a/public/react/components/App.js
+++ b/public/react/components/App.js
@@ -45,21 +45,13 @@ export const App = () => {
 
   return (
     <div>
-      <Link to="/">Home</Link>
-      <Link to="/items">items</Link>
-      {[1, 2, 3].map((id) => (
-        <Link to={`/item/${id}`}>Link to: {id}</Link>
-      ))}
       <Routes>
-        <Route
-          path="/"
-          element={
-            <main>
-              <h1>Home</h1>
-            </main>
-          }
-        />
-        <Route path="/item/:id" element={<ComponentWithID />} />
+        {/* TODO: this will link to an item component  */}
+        {/* Link will be inside itemslist in this format: */}
+        {/* {items.map((id) => ( */}
+        {/*   <Link to={`/item/${id}`}>Link to: {id}</Link> */}
+        {/* ))} */}
+        <Route path="/item/:id" element={<div></div>} />
       </Routes>
     </div>
   );

--- a/public/react/components/App.js
+++ b/public/react/components/App.js
@@ -1,63 +1,34 @@
+//  this file (app) should only have routes
+// main view should have itemslist etc
 import React, { useState, useEffect } from "react";
-import { ItemsList } from "./ItemsList";
-import { Route, Routes } from "react-router-dom";
+import { MainView } from "./MainView";
+import { Route, Routes, useParams } from "react-router-dom";
 
-// import and prepend the api url to any fetch calls
-import apiURL from "../api";
+// this shows how to get id from url with useParam
+// Link will be inside itemslist in this format:
+// {items.map((id) => (
+//   <Link to={`/item/${id}`}>Link to: {id}</Link>
+// ))}
 
-export const App = () => {
-  const [sauces, setSauces] = useState([]);
-  const [items, setItems] = useState([]);
-
-  async function fetchSauces() {
-    try {
-      const response = await fetch(`${apiURL}/sauces`);
-      const saucesData = await response.json();
-      setSauces(saucesData);
-    } catch (err) {
-      console.log("Oh no an error! ", err);
-    }
-  }
-
-  useEffect(() => {
-    fetchSauces();
-  }, []);
-
-  //GET fetch request for all items
-  async function fetchItems() {
-    try {
-      const res = await fetch(`${apiURL}/items`);
-      const itemsData = await res.json();
-      setItems(itemsData);
-    } catch (err) {
-      console.log("Error!", err);
-    }
-  }
-
-  useEffect(() => {
-    fetchItems();
-  }, []);
+const Item = () => {
+  const { id } = useParams();
 
   return (
     <div>
-      <Routes>
-        {/* TODO: create main view */}
-        {/* this file (app) should only have routes */}
-        {/* main view should have itemslist etc */}
-        <Route path="/" element={<ItemsList items={items} />} />
-        {/* TODO: this will link to an item component  */}
-        {/* Link will be inside itemslist in this format: */}
-        {/* {items.map((id) => ( */}
-        {/*   <Link to={`/item/${id}`}>Link to: {id}</Link> */}
-        {/* ))} */}
-        <Route path="/item/:id" element={<div></div>} />
-      </Routes>
+      <h1>This is the id: {id}</h1>
     </div>
   );
 };
+
+export const App = () => {
+  // routes is how react-router renders the element and changes the url without reloading the page
+  return (
+    <main>
+      <Routes>
+        <Route path="/" element={<MainView />} />
+        <Route path="/item/:id" element={<Item />} />
+      </Routes>
+    </main>
+  );
+};
 // temporary
-// {/* <main> */}
-// {/*   <h1 className="heading">Sauce Store</h1> */}
-// {/*   <h3 id="heading2">All things 🔥</h3> */}
-// {/*   <ItemsList items={items} /> */}
-// {/* </main> */}

--- a/public/react/components/MainView.jsx
+++ b/public/react/components/MainView.jsx
@@ -1,8 +1,10 @@
 import apiURL from "../api";
+import { ItemsList } from "./ItemsList";
+import React, { useState, useEffect } from "react";
+
 // import and prepend the api url to any fetch calls
 
 export const MainView = () => {
-  const [sauces, setSauces] = useState([]);
   const [items, setItems] = useState([]);
 
   async function fetchSauces() {

--- a/public/react/components/MainView.jsx
+++ b/public/react/components/MainView.jsx
@@ -1,0 +1,46 @@
+import apiURL from "../api";
+// import and prepend the api url to any fetch calls
+
+export const MainView = () => {
+  const [sauces, setSauces] = useState([]);
+  const [items, setItems] = useState([]);
+
+  async function fetchSauces() {
+    try {
+      const response = await fetch(`${apiURL}/sauces`);
+      const saucesData = await response.json();
+      setSauces(saucesData);
+    } catch (err) {
+      console.log("Oh no an error! ", err);
+    }
+  }
+
+  useEffect(() => {
+    fetchSauces();
+  }, []);
+
+  //GET fetch request for all items
+  async function fetchItems() {
+    try {
+      const res = await fetch(`${apiURL}/items`);
+      const itemsData = await res.json();
+      setItems(itemsData);
+    } catch (err) {
+      console.log("Error!", err);
+    }
+  }
+
+  useEffect(() => {
+    fetchItems();
+  }, []);
+
+  return (
+    <>
+      <main>
+        <h1 className="heading">Sauce Store</h1>
+        <h3 id="heading2">All things 🔥</h3>
+        <ItemsList items={items} />
+      </main>
+    </>
+  );
+};

--- a/public/react/index.js
+++ b/public/react/index.js
@@ -1,8 +1,17 @@
 import React from "react";
-import { createRoot } from 'react-dom/client';
-import 'regenerator-runtime/runtime'
+import { createRoot } from "react-dom/client";
+// TODO: Could this be causing the issues with test? (investigate)
+import "regenerator-runtime/runtime";
 
-import {App} from './components/App';
+import { BrowserRouter } from "react-router-dom";
+
+import { App } from "./components/App";
 
 const root = createRoot(document.getElementById("root"));
-root.render(<App />);
+root.render(
+  <>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </>
+);


### PR DESCRIPTION
closes #12 
This is a change to how we had our project set up before. 

It makes uses of the [react router](https://reactrouter.com/en/main) library to act like a traditional website with clickable links while still rendering like a React Single Page App. 
This is done by first
1. adding BrowserRouter within the index.js
2. setting up the ```<routes>``` component inside of the app. Everything inside of the routes component will be switched out when we go to a new link
3. adding individual ```<route>```s within the ```<routes>```. Still to do is to add the actual Item component when Surafel pr's it, and to add the add item form button route

I moved the code previously worked on in issue #6 to its own component and file titled ```<MainView>``` (```<Home>``` might make more sense)